### PR TITLE
Provider -> DateTimeProvider

### DIFF
--- a/src/Provider/ConstantDateTimeProvider.php
+++ b/src/Provider/ConstantDateTimeProvider.php
@@ -14,7 +14,7 @@ namespace Kdyby\DateTimeProvider\Provider;
 
 use DateTimeImmutable;
 
-class MutableProvider
+class ConstantDateTimeProvider
 	implements
 		\Kdyby\DateTimeProvider\DateTimeProviderInterface,
 		\Kdyby\DateTimeProvider\DateProviderInterface,
@@ -22,7 +22,7 @@ class MutableProvider
 		\Kdyby\DateTimeProvider\TimeZoneProviderInterface
 {
 
-	use \Kdyby\DateTimeProvider\Provider\ProviderTrait;
+	use \Kdyby\DateTimeProvider\Provider\ImmutableDateTimeProviderTrait;
 	use \Kdyby\StrictObjects\Scream;
 
 	/**
@@ -30,19 +30,14 @@ class MutableProvider
 	 */
 	private $prototype;
 
-	public function __construct(DateTimeImmutable $prototype)
+	public function __construct(DateTimeImmutable $dateTime)
 	{
-		$this->prototype = $prototype;
+		$this->prototype = $dateTime;
 	}
 
 	protected function getPrototype(): DateTimeImmutable
 	{
 		return $this->prototype;
-	}
-
-	public function changePrototype(DateTimeImmutable $prototype): void
-	{
-		$this->prototype = $prototype;
 	}
 
 }

--- a/src/Provider/ConstantDateTimeProviderFactory.php
+++ b/src/Provider/ConstantDateTimeProviderFactory.php
@@ -19,7 +19,7 @@ use DateTimeZone;
 /**
  * Helper factory to create ConstantProvider from arbitrary input.
  */
-class ConstantProviderFactory
+class ConstantDateTimeProviderFactory
 {
 
 	use \Kdyby\StrictObjects\Scream;
@@ -27,16 +27,16 @@ class ConstantProviderFactory
 	/**
 	 * @param string|int|\DateTimeImmutable|\DateTime $dateTime
 	 */
-	public function create($dateTime): ConstantProvider
+	public function create($dateTime): ConstantDateTimeProvider
 	{
 		if ($dateTime instanceof DateTimeImmutable) {
-			return new ConstantProvider($dateTime);
+			return new ConstantDateTimeProvider($dateTime);
 
 		} elseif ($dateTime instanceof DateTime) {
-			return new ConstantProvider(DateTimeImmutable::createFromMutable($dateTime));
+			return new ConstantDateTimeProvider(DateTimeImmutable::createFromMutable($dateTime));
 
 		} elseif (is_numeric($dateTime)) {
-			return new ConstantProvider((new DateTimeImmutable(sprintf('@%.6f', $dateTime)))->setTimezone(new DateTimeZone(date_default_timezone_get())));
+			return new ConstantDateTimeProvider((new DateTimeImmutable(sprintf('@%.6f', $dateTime)))->setTimezone(new DateTimeZone(date_default_timezone_get())));
 
 		} elseif (is_string($dateTime)) {
 			throw new \Kdyby\DateTimeProvider\NotImplementedException(sprintf(

--- a/src/Provider/CurrentDateTimeProvider.php
+++ b/src/Provider/CurrentDateTimeProvider.php
@@ -14,7 +14,7 @@ namespace Kdyby\DateTimeProvider\Provider;
 
 use DateTimeImmutable;
 
-class ConstantProvider
+class CurrentDateTimeProvider
 	implements
 		\Kdyby\DateTimeProvider\DateTimeProviderInterface,
 		\Kdyby\DateTimeProvider\DateProviderInterface,
@@ -22,22 +22,15 @@ class ConstantProvider
 		\Kdyby\DateTimeProvider\TimeZoneProviderInterface
 {
 
-	use \Kdyby\DateTimeProvider\Provider\ImmutableProviderTrait;
+	use \Kdyby\DateTimeProvider\Provider\DateTimeProviderTrait;
 	use \Kdyby\StrictObjects\Scream;
 
 	/**
-	 * @var \DateTimeImmutable
+	 * {@inheritdoc}
 	 */
-	private $prototype;
-
-	public function __construct(DateTimeImmutable $dateTime)
+	public function getPrototype(): DateTimeImmutable
 	{
-		$this->prototype = $dateTime;
-	}
-
-	protected function getPrototype(): DateTimeImmutable
-	{
-		return $this->prototype;
+		return new DateTimeImmutable();
 	}
 
 }

--- a/src/Provider/DateTimeProviderTrait.php
+++ b/src/Provider/DateTimeProviderTrait.php
@@ -19,7 +19,7 @@ use DateTimeZone;
 /**
  * Base implementation for DateTime-based providers.
  */
-trait ProviderTrait
+trait DateTimeProviderTrait
 {
 
 	abstract protected function getPrototype(): DateTimeImmutable;

--- a/src/Provider/ImmutableDateTimeProviderTrait.php
+++ b/src/Provider/ImmutableDateTimeProviderTrait.php
@@ -19,10 +19,10 @@ use DateTimeZone;
 /**
  * Provides some optimizations for providers with guaranteed immutability.
  */
-trait ImmutableProviderTrait
+trait ImmutableDateTimeProviderTrait
 {
 
-	use \Kdyby\DateTimeProvider\Provider\ProviderTrait {
+	use \Kdyby\DateTimeProvider\Provider\DateTimeProviderTrait {
 		getDate as getDateVolatile;
 		getTime as getTimeVolatile;
 		getTimeZone as getTimeZoneVolatile;

--- a/src/Provider/MutableDateTimeProvider.php
+++ b/src/Provider/MutableDateTimeProvider.php
@@ -14,7 +14,7 @@ namespace Kdyby\DateTimeProvider\Provider;
 
 use DateTimeImmutable;
 
-class CurrentProvider
+class MutableDateTimeProvider
 	implements
 		\Kdyby\DateTimeProvider\DateTimeProviderInterface,
 		\Kdyby\DateTimeProvider\DateProviderInterface,
@@ -22,15 +22,27 @@ class CurrentProvider
 		\Kdyby\DateTimeProvider\TimeZoneProviderInterface
 {
 
-	use \Kdyby\DateTimeProvider\Provider\ProviderTrait;
+	use \Kdyby\DateTimeProvider\Provider\DateTimeProviderTrait;
 	use \Kdyby\StrictObjects\Scream;
 
 	/**
-	 * {@inheritdoc}
+	 * @var \DateTimeImmutable
 	 */
-	public function getPrototype(): DateTimeImmutable
+	private $prototype;
+
+	public function __construct(DateTimeImmutable $prototype)
 	{
-		return new DateTimeImmutable();
+		$this->prototype = $prototype;
+	}
+
+	protected function getPrototype(): DateTimeImmutable
+	{
+		return $this->prototype;
+	}
+
+	public function changePrototype(DateTimeImmutable $prototype): void
+	{
+		$this->prototype = $prototype;
 	}
 
 }

--- a/tests/DateTimeProvider/ConstantDateTimeProviderFactoryTest.phpt
+++ b/tests/DateTimeProvider/ConstantDateTimeProviderFactoryTest.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Kdyby\DateTimeProvider\ConstantProvider.
+ * Test: Kdyby\DateTimeProvider\ConstantDateTimeProviderFactory.
  *
  * @testCase KdybyTests\DateTimeProvider\ConstantProviderTest
  */
@@ -12,18 +12,18 @@ namespace KdybyTests\DateTimeProvider;
 
 use DateTime;
 use DateTimeImmutable;
-use Kdyby\DateTimeProvider\Provider\ConstantProviderFactory;
+use Kdyby\DateTimeProvider\Provider\ConstantDateTimeProviderFactory;
 use Tester\Assert;
 use stdClass;
 
 require_once __DIR__ . '/../bootstrap.php';
 
-class ConstantProviderFactoryTest extends \Tester\TestCase
+class ConstantDateTimeProviderFactoryTest extends \Tester\TestCase
 {
 
 	public function testCreateFromNumeric(): void
 	{
-		$tp = (new ConstantProviderFactory())->create(1379123601);
+		$tp = (new ConstantDateTimeProviderFactory())->create(1379123601);
 		$datetime = $tp->getDateTime();
 		$date = $tp->getDate();
 		$time = $tp->getTime();
@@ -40,7 +40,7 @@ class ConstantProviderFactoryTest extends \Tester\TestCase
 
 	public function testCreateFromMutableDatetime(): void
 	{
-		$tp = (new ConstantProviderFactory())->create(new DateTime('2013-09-14 03:53:21'));
+		$tp = (new ConstantDateTimeProviderFactory())->create(new DateTime('2013-09-14 03:53:21'));
 		$datetime = $tp->getDateTime();
 		$date = $tp->getDate();
 		$time = $tp->getTime();
@@ -57,7 +57,7 @@ class ConstantProviderFactoryTest extends \Tester\TestCase
 
 	public function testCreateFromMutableDatetimeImmutable(): void
 	{
-		$tp = (new ConstantProviderFactory())->create(new DateTimeImmutable('2013-09-14 03:53:21'));
+		$tp = (new ConstantDateTimeProviderFactory())->create(new DateTimeImmutable('2013-09-14 03:53:21'));
 		$datetime = $tp->getDateTime();
 		$date = $tp->getDate();
 		$time = $tp->getTime();
@@ -76,31 +76,31 @@ class ConstantProviderFactoryTest extends \Tester\TestCase
 	{
 		date_default_timezone_set('Europe/Prague');
 
-		$tp = (new ConstantProviderFactory())->create(1379123601);
+		$tp = (new ConstantDateTimeProviderFactory())->create(1379123601);
 		Assert::same('Europe/Prague', $tp->getTimeZone()->getName());
 		Assert::same('2013-09-14 03:53:21.000000 +02:00', $tp->getDateTime()->format('Y-m-d H:i:s.u P'));
 
 		date_default_timezone_set('Europe/London');
 
-		$tp = (new ConstantProviderFactory())->create(1379123601);
+		$tp = (new ConstantDateTimeProviderFactory())->create(1379123601);
 		Assert::same('Europe/London', $tp->getTimeZone()->getName());
 		Assert::same('2013-09-14 02:53:21.000000 +01:00', $tp->getDateTime()->format('Y-m-d H:i:s.u P'));
 	}
 
 	public function testCreateFromUnknownException(): void
 	{
-		Assert::exception(function () {
-			(new ConstantProviderFactory())->create('blablabla');
+		Assert::exception(function (): void {
+			(new ConstantDateTimeProviderFactory())->create('blablabla');
 		}, \Kdyby\DateTimeProvider\NotImplementedException::class, 'Cannot process datetime in given format "blablabla"');
 
-		Assert::exception(function () {
-			(new ConstantProviderFactory())->create(new stdClass());
+		Assert::exception(function (): void {
+			(new ConstantDateTimeProviderFactory())->create(new stdClass());
 		}, \Kdyby\DateTimeProvider\NotImplementedException::class, 'Cannot process datetime from given value stdClass');
 	}
 
 	public function testCreateFromMicroseconds(): void
 	{
-		$tp = (new ConstantProviderFactory())->create(1379123601.123456);
+		$tp = (new ConstantDateTimeProviderFactory())->create(1379123601.123456);
 		$datetime = $tp->getDateTime();
 		$date = $tp->getDate();
 		$time = $tp->getTime();
@@ -118,4 +118,4 @@ class ConstantProviderFactoryTest extends \Tester\TestCase
 
 }
 
-(new ConstantProviderFactoryTest())->run();
+(new ConstantDateTimeProviderFactoryTest())->run();

--- a/tests/DateTimeProvider/ConstantDateTimeProviderTest.phpt
+++ b/tests/DateTimeProvider/ConstantDateTimeProviderTest.phpt
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Test: Kdyby\DateTimeProvider\ConstantProvider.
+ * Test: Kdyby\DateTimeProvider\ConstantDateTimeProvider.
  *
- * @testCase KdybyTests\DateTimeProvider\ConstantProviderTest
+ * @testCase KdybyTests\DateTimeProvider\ConstantDateTimeProviderTest
  */
 
 declare(strict_types = 1);
@@ -11,17 +11,17 @@ declare(strict_types = 1);
 namespace KdybyTests\DateTimeProvider;
 
 use DateTimeImmutable;
-use Kdyby\DateTimeProvider\Provider\ConstantProvider;
+use Kdyby\DateTimeProvider\Provider\ConstantDateTimeProvider;
 use Tester\Assert;
 
 require_once __DIR__ . '/../bootstrap.php';
 
-class ConstantProviderTest extends \Tester\TestCase
+class ConstantDateTimeProviderTest extends \Tester\TestCase
 {
 
 	public function testConstant(): void
 	{
-		$tp = new ConstantProvider(new DateTimeImmutable('2013-09-14 03:53:21.123456'));
+		$tp = new ConstantDateTimeProvider(new DateTimeImmutable('2013-09-14 03:53:21.123456'));
 		$datetime = $tp->getDateTime();
 		$date = $tp->getDate();
 		$time = $tp->getTime();
@@ -37,4 +37,4 @@ class ConstantProviderTest extends \Tester\TestCase
 
 }
 
-(new ConstantProviderTest())->run();
+(new ConstantDateTimeProviderTest())->run();

--- a/tests/DateTimeProvider/CurrentDateTimeProviderTest.phpt
+++ b/tests/DateTimeProvider/CurrentDateTimeProviderTest.phpt
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Test: Kdyby\DateTimeProvider\CurrentProvider.
+ * Test: Kdyby\DateTimeProvider\CurrentDateTimeProvider.
  *
- * @testCase KdybyTests\DateTimeProvider\CurrentProviderTest
+ * @testCase KdybyTests\DateTimeProvider\CurrentDateTimeProviderTest
  */
 
 declare(strict_types = 1);
@@ -11,17 +11,17 @@ declare(strict_types = 1);
 namespace KdybyTests\DateTimeProvider;
 
 use DateTimeImmutable;
-use Kdyby\DateTimeProvider\Provider\CurrentProvider;
+use Kdyby\DateTimeProvider\Provider\CurrentDateTimeProvider;
 use Tester\Assert;
 
 require_once __DIR__ . '/../bootstrap.php';
 
-class CurrentProviderTest extends \Tester\TestCase
+class CurrentDateTimeProviderTest extends \Tester\TestCase
 {
 
 	public function testNotConstant(): void
 	{
-		$tp = new CurrentProvider();
+		$tp = new CurrentDateTimeProvider();
 		$date = $tp->getDate();
 		$datetime = $tp->getDateTime();
 		$time = $tp->getTime();
@@ -40,15 +40,15 @@ class CurrentProviderTest extends \Tester\TestCase
 	{
 		date_default_timezone_set('Europe/Prague');
 
-		$tp = new CurrentProvider();
+		$tp = new CurrentDateTimeProvider();
 		Assert::same('Europe/Prague', $tp->getTimeZone()->getName());
 
 		date_default_timezone_set('Europe/London');
 
-		$tp = new CurrentProvider();
+		$tp = new CurrentDateTimeProvider();
 		Assert::same('Europe/London', $tp->getTimeZone()->getName());
 	}
 
 }
 
-(new CurrentProviderTest())->run();
+(new CurrentDateTimeProviderTest())->run();

--- a/tests/DateTimeProvider/MutableDateTimeProviderTest.phpt
+++ b/tests/DateTimeProvider/MutableDateTimeProviderTest.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Kdyby\DateTimeProvider\MutableProvider.
+ * Test: Kdyby\DateTimeProvider\MutableDateTimeProvider.
  *
  * @testCase
  */
@@ -11,17 +11,17 @@ declare(strict_types = 1);
 namespace KdybyTests\DateTimeProvider;
 
 use DateTimeImmutable;
-use Kdyby\DateTimeProvider\Provider\MutableProvider;
+use Kdyby\DateTimeProvider\Provider\MutableDateTimeProvider;
 use Tester\Assert;
 
 require_once __DIR__ . '/../bootstrap.php';
 
-class MutableProviderTest extends \Tester\TestCase
+class MutableDateTimeProviderTest extends \Tester\TestCase
 {
 
 	public function testConstant(): void
 	{
-		$tp = new MutableProvider(new DateTimeImmutable('2013-09-14 03:53:21'));
+		$tp = new MutableDateTimeProvider(new DateTimeImmutable('2013-09-14 03:53:21'));
 		$datetime = $tp->getDateTime();
 		$date = $tp->getDate();
 		$time = $tp->getTime();
@@ -39,20 +39,20 @@ class MutableProviderTest extends \Tester\TestCase
 	{
 		date_default_timezone_set('Europe/Prague');
 
-		$tp = new MutableProvider(new DateTimeImmutable(date('Y-m-d H:i:s', 1379123601)));
+		$tp = new MutableDateTimeProvider(new DateTimeImmutable(date('Y-m-d H:i:s', 1379123601)));
 		Assert::same('Europe/Prague', $tp->getTimeZone()->getName());
 		Assert::same('2013-09-14 03:53:21 +02:00', $tp->getDateTime()->format('Y-m-d H:i:s P'));
 
 		date_default_timezone_set('Europe/London');
 
-		$tp = new MutableProvider(new DateTimeImmutable(date('Y-m-d H:i:s', 1379123601)));
+		$tp = new MutableDateTimeProvider(new DateTimeImmutable(date('Y-m-d H:i:s', 1379123601)));
 		Assert::same('Europe/London', $tp->getTimeZone()->getName());
 		Assert::same('2013-09-14 02:53:21 +01:00', $tp->getDateTime()->format('Y-m-d H:i:s P'));
 	}
 
 	public function testChangePrototype(): void
 	{
-		$tp = new MutableProvider($originalTime = new DateTimeImmutable('2013-09-14 03:53:21'));
+		$tp = new MutableDateTimeProvider($originalTime = new DateTimeImmutable('2013-09-14 03:53:21'));
 		Assert::same($originalTime, $tp->getDateTime());
 
 		$tp->changePrototype($changedTime = new DateTimeImmutable('2015-01-09 18:34:00'));
@@ -62,7 +62,7 @@ class MutableProviderTest extends \Tester\TestCase
 
 	public function testMicroseconds(): void
 	{
-		$tp = new MutableProvider(new DateTimeImmutable('2013-09-14 03:53:21.123456'));
+		$tp = new MutableDateTimeProvider(new DateTimeImmutable('2013-09-14 03:53:21.123456'));
 		$datetime = $tp->getDateTime();
 		$date = $tp->getDate();
 		$time = $tp->getTime();
@@ -78,4 +78,4 @@ class MutableProviderTest extends \Tester\TestCase
 
 }
 
-(new MutableProviderTest())->run();
+(new MutableDateTimeProviderTest())->run();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/327717/30512405-3335df94-9aef-11e7-9c2f-c6a81550067f.png)

Everytime I look into my code I see _XProvider_ and I'm like 
> huh, wat provider
![image](https://user-images.githubusercontent.com/327717/30512432-b4d7898a-9aef-11e7-96b0-8ae00d59f156.png)

I'd prefer more exact name. That's the reason for this BC break PR.

_(at least I tried :P )_