### PR TITLE
Fix license names deprecated in SPDX 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"description": "Time provider, providing consistent current date, time, datetime and timezone across the request.",
 	"keywords": ["kdyby", "date", "time", "datetime", "microseconds", "clock", "provider"],
 	"homepage": "http://kdyby.org",
-	"license": ["BSD-3-Clause", "GPL-2.0", "GPL-3.0"],
+	"license": ["BSD-3-Clause", "GPL-2.0-only", "GPL-3.0-only"],
 	"authors": [
 		{
 			"name": "Michael Moravec"


### PR DESCRIPTION
I'd drop GPL entirely, but it's up to @fprochazka, so only changing to new name for now.